### PR TITLE
Implemented Polymorphic `Encoder `and `Decoder` modules. Cleaned up the codes

### DIFF
--- a/CommTypes.bsv
+++ b/CommTypes.bsv
@@ -18,7 +18,8 @@ typedef Bit#(1024) Line;
 typedef Bit#(512) MemData;
 
 //typedef FixedPoint#(16,16) Coeff;
-typedef Int#(12) Coeff;
+typedef 12 WC;
+typedef Int#(WC) Coeff;
 
 //typedef Bit#(24) Addr;
 //add line type

--- a/dwt/Makefile
+++ b/dwt/Makefile
@@ -6,13 +6,13 @@ default: full_clean compile link simulate
 .PHONY: compile
 compile:
 	@echo Compiling...
-	bsc -u -sim -simdir . -bdir bscdir -info-dir . -keep-fires -steps-warn-interval 100000 -steps-max-intervals 100 -show-schedule -aggressive-conditions -D SIM -p .:%/Prelude:%/Libraries:%/Libraries/BlueNoC -g mkDWT2DTest  dwt2d_test.bsv 
+	bsc -u -sim -simdir . -bdir bscdir -info-dir . -keep-fires -steps-warn-interval 100000 -steps-max-intervals 100 -show-schedule -aggressive-conditions -D SIM -p .:../serialize:../deserialize:../huffman:..:../includes:%/Prelude:%/Libraries:%/Libraries/BlueNoC -g mkDWT2DTest  dwt2d_test.bsv 
 	@echo Compilation finished
 
 .PHONY: link
 link:
 	@echo Linking...
-	bsc -e mkDWT2DTest -sim -o ./out -simdir . -p .:%/Prelude:%/Libraries:%/Libraries/BlueNoC -bdir bscdir -keep-fires 
+	bsc -e mkDWT2DTest -sim -o ./out -simdir . -p .:../serialize:../deserialize:../huffman:..:../includes:%/Prelude:%/Libraries:%/Libraries/BlueNoC -bdir bscdir -keep-fires 
 	@echo Linking finished
 
 .PHONY: simulate

--- a/dwt/dwt2d_test.bsv
+++ b/dwt/dwt2d_test.bsv
@@ -6,18 +6,20 @@ import FShow::*;
 import DWT2D::*;
 import DWT2DML::*;
 import DWTTypes::*;
+import huffmanLoopBack::*;
 
-typedef 32 N;
-typedef 32 M;
+typedef 16 N;
+typedef 16 M;
 typedef 4 B;
 typedef 1 T;
-typedef 3 L;
+typedef 1 L;
 
       
 // Unit test for DWT module
 (* synthesize *)
 module mkDWT2DTest (Empty);
 	DWT2DMLI#(N,M,B,L) dwt2d <- mkDWT2DMLI();
+	HuffmanLoopBack#(B) huffman <- mkHuffmanLoopBack();
 	IDWT2DMLI#(N,M,B,L) idwt2d <- mkIDWT2DMLI();
 	
 	Reg#(Bool) m_inited <- mkReg(False);
@@ -37,9 +39,18 @@ module mkDWT2DTest (Empty);
     endrule
 
 	(* fire_when_enabled *)
-	rule dwt2idwt;
+	rule dwt2huffman;
 		let x <- dwt2d.response.get();
+		huffman.request.put(x);
+        $display("%t to   Huffman:",$time, fshow(x));
+		//idwt2d.request.put(x);
+	endrule
+	
+	(* fire_when_enabled *)
+	rule huffman2idwdt;
+		let x <- huffman.response.get();
 		idwt2d.request.put(x);
+        $display("%t from Huffman:",$time, fshow(x));
 	endrule
 
     rule send(m_inited && m_line_in < fromInteger(valueOf(M)) && t<fromInteger(valueOf(T)));

--- a/dwt/dwt2d_test.bsv
+++ b/dwt/dwt2d_test.bsv
@@ -12,7 +12,7 @@ typedef 16 N;
 typedef 16 M;
 typedef 4 B;
 typedef 1 T;
-typedef 1 L;
+typedef 3 L;
 
       
 // Unit test for DWT module
@@ -92,10 +92,14 @@ module mkDWT2DTest (Empty);
     	m_line_out <= m_line_out + 1;
     endrule
     
-    rule finish(m_inited && m_line_out == fromInteger(valueOf(N)*valueOf(M)/valueOf(B)*valueOf(T)) && t==fromInteger(valueOf(T)));
-//    	$fclose(m_in);
-//    	$fclose(m_out);
-    	$display("Done");
+    rule flush(m_inited && t==fromInteger(valueOf(T)));
+    	// Keep Flushing with junk when done
+    	$display("%t Flush",$time);
+    	dwt2d.request.put(replicate(0));
+    endrule
+    
+    rule finish(m_inited && m_line_out == fromInteger(valueOf(N)*valueOf(M)/valueOf(B)*valueOf(T)));
+    	$display("Done at %t", $time);
     	$finish;
     endrule
 endmodule

--- a/huffman/Decoder.bsv
+++ b/huffman/Decoder.bsv
@@ -1,6 +1,6 @@
 import ClientServer::*;
 import GetPut::*;
-import Fifo::*;
+import FIFO::*;
 import Vector::*;
 import FixedPoint::*;
 
@@ -13,8 +13,8 @@ typedef Server#(
 
 (* synthesize *)
 module mkDecoder(Decode ifc);
-   Fifo#(2,Bit#(1)) inputFIFO <- mkCFFifo;
-   Fifo#(2,Coeff) outputFIFO <- mkCFFifo; //do need another chunker?
+   FIFO#(Bit#(1)) inputFIFO <- mkFIFO;
+   FIFO#(Coeff) outputFIFO <- mkFIFO; //do need another chunker?
    //integer of full precision
    Vector#(16,Reg#(Bit#(1))) storedBits <- replicateM(mkReg(0));
    Reg#(Bit#(5)) numberBits <- mkReg(0);
@@ -27,8 +27,8 @@ module mkDecoder(Decode ifc);
       inputFIFO.deq;
       Bit#(5) tempNumberBits = 0;
       Coeff x = 0;
-      //$display("new bit:", newBit);
-      //$display("number bits:", numberBits);
+      $display("new bit:", newBit);
+      $display("number bits:", numberBits);
       case (numberBits)
 	 5'd0: 
 	 begin
@@ -118,9 +118,8 @@ module mkDecoder(Decode ifc);
 	       out[i] = storedBits[i];
 	    end 
 	    out[15] = newBit;
-	    //$display("bits:%b",out);
-	    Int#(16) iout = unpack(out);
-	    x = fromInt(iout);
+	    x = unpack(truncate(out));
+	    $display("decode:%d",x);
 	     //will prob have type problems
 	    //$display("bits:%b,int:%d,fp:",out,iout,fshow(x));
 	    tempNumberBits = 0;

--- a/huffman/Decoder.bsv
+++ b/huffman/Decoder.bsv
@@ -8,9 +8,7 @@ import CommTypes::*;
 
 typedef Server#(
 		Byte,
-		//Bit#(1),
 		Vector#(p,Coeff)
-		//Coeff
 		)Decode#(numeric type p);
 
 

--- a/huffman/Decoder.bsv
+++ b/huffman/Decoder.bsv
@@ -178,8 +178,8 @@ module mkDecoder(Decode ifc);
       inputFIFO.deq;
       Bit#(5) tempNumberBits = 0;
       Coeff x = 0;
-      $display("new bit:", newBit);
-      $display("number bits:", numberBits);
+      /*$display("new bit:", newBit);
+      $display("number bits:", numberBits);*/
       case (numberBits)
 	 5'd0: 
 	 begin
@@ -270,7 +270,7 @@ module mkDecoder(Decode ifc);
 	    end 
 	    out[15] = newBit;
 	    x = unpack(truncate(out));
-	    $display("decode:%d",x);
+	    //$display("decode:%d",x);
 	     //will prob have type problems
 	    //$display("bits:%b,int:%d,fp:",out,iout,fshow(x));
 	    tempNumberBits = 0;
@@ -291,11 +291,7 @@ module mkDecoder(Decode ifc);
       end
    endrule
    
-   interface Put request;
-      method Action put (Bit#(1) x);
-	 inputFIFO.enq(x);
-      endmethod
-   endinterface
+   interface Put request = toPut(inputFIFO);
    interface Get response = toGet(outputFIFO);
       
 endmodule

--- a/huffman/Decoder_v2.bsv
+++ b/huffman/Decoder_v2.bsv
@@ -1,0 +1,87 @@
+import ClientServer::*;
+import GetPut::*;
+import FIFO::*;
+import Vector::*;
+import FixedPoint::*;
+import Ehr::*;
+import CommTypes::*;
+import HuffmanTable::*;
+
+typedef Server#(
+	Bit#(b),
+	Bit#(c)
+)Decoder#(numeric type b, numeric type c);
+
+module mkDecoder(HuffmanTable#(s, c, n)  ht, Decoder#(b,c) ifc);
+	// Max length of each token
+	Integer maxTokenLen = valueOf(n) + valueOf(c);
+	
+	FIFO#(Bit#(b)) inputFIFO <- mkFIFO;
+	FIFO#(Bit#(c)) outputFIFO <- mkFIFO;
+
+	Vector#(64,Ehr#(2, Maybe#(Bit#(1)))) bitBuffer <- replicateM(mkEhr(Invalid));
+	Reg#(Bit#(6)) w_index <- mkReg(0);
+	Reg#(Bit#(6)) r_index <- mkReg(0);
+	
+	rule stage_load (!isValid(bitBuffer[w_index + fromInteger(valueOf(b)) - 1][1]));
+		let in = inputFIFO.first; inputFIFO.deq;
+		for (Integer i = 0; i < valueOf(b); i=i+1) begin
+			bitBuffer[w_index+fromInteger(i)][1] <= tagged Valid in[i];
+		end
+		// Automatically warp
+		w_index <= w_index + fromInteger(valueOf(b));
+		$display("%t Decoder: load %b", $time, in);
+	endrule
+
+	rule stage_decode (isValid(bitBuffer[r_index][0]));
+		Vector#(n, Maybe#(Bit#(1))) tok = newVector;
+		Bit#(n) ftok = ?;
+		Bit#(c) out = ?;
+		Bit#(6) size = ?;
+		
+		for(Integer i=0; i < valueOf(n); i = i+1)begin
+			tok[i] = bitBuffer[r_index + fromInteger(i)][0];
+			ftok[i] = fromMaybe(0, tok[i]);
+		end
+		Bool hit = False;
+		for(Integer i=0; i < valueOf(s); i = i+1)begin
+			Bool thishit = True;
+			Bit#(n) rtoken = reverseBits(ht[i].token);
+			for(Integer j=0; j < valueOf(n); j = j+1)begin
+				if(fromInteger(j) < ht[i].size && (!isValid(tok[j]) || rtoken[j] != fromMaybe(?, tok[j])))begin
+					// Missed
+					thishit = False;
+				end
+			end
+			if(thishit)begin
+				hit = True;
+				out = ht[i].tag;
+				size = ht[i].size;
+			end
+		end
+		// When we have out of table values, and the long token is ready to be fetched
+		if(ftok=='1 && isValid(bitBuffer[r_index + fromInteger(maxTokenLen) - 1][0]))begin
+			hit = True;
+			for(Integer i=0; i<valueOf(c); i=i+1)begin
+				out[i] = fromMaybe(?, bitBuffer[r_index + fromInteger(valueOf(n) + i)][0]);
+			end
+			out = reverseBits(out);
+			size = fromInteger(maxTokenLen);
+		end
+		
+		if(hit)begin
+			// We're hit
+			$display("%t Decoder: decode %b'%d -> %d", $time, ftok, size, out);
+			outputFIFO.enq(out);
+			for(Integer i=0; i<maxTokenLen; i=i+1)begin
+				if(fromInteger(i) < size)begin
+					bitBuffer[r_index + fromInteger(i)][0] <= tagged Invalid;
+				end
+			end
+			r_index <= r_index + size;
+		end
+	endrule
+      
+	interface Put request = toPut(inputFIFO);
+	interface Get response = toGet(outputFIFO);
+endmodule

--- a/huffman/Encoder.bsv
+++ b/huffman/Encoder.bsv
@@ -185,7 +185,7 @@ module mkEncoder(Encode#(p) ifc);
       end
       if (w_index + curr.size > 63) begin //*fromInteger(valueOf(p))) begin
 	 w_index <= (w_index + curr.size) - 63;//*fromInteger(valueOf(p));
-	 $display("wrap:",w_index + 22 - 63);
+	 //$display("wrap:",w_index + 22 - 63);
       end
       else begin
 	 w_index <= w_index + curr.size;
@@ -220,11 +220,7 @@ module mkEncoder(Encode#(p) ifc);
       outputFIFO.enq(out);
    endrule
   
-   interface Put request;
-      method Action put (Vector#(p,Coeff) x);
-	 inputFIFO.enq(x);
-      endmethod
-   endinterface
+   interface Put request = toPut(inputFIFO);
    interface Get response = toGet(outputFIFO);
 
 endmodule

--- a/huffman/Encoder_v2.bsv
+++ b/huffman/Encoder_v2.bsv
@@ -1,0 +1,88 @@
+import ClientServer::*;
+import GetPut::*;
+import FIFO::*;
+import Vector::*;
+import FixedPoint::*;
+import HuffmanTable::*;
+import CommTypes::*;
+import Ehr::*;
+
+typedef Server#(
+	Bit#(c), // Coefficient input
+	Bit#(b)  // Byte output
+) Encoder#(numeric type c, numeric type b);
+
+typedef struct {
+	Bit#(6) size;
+	Bit#(n) token;
+} Encoding#(numeric type n) deriving (Eq, Bits);
+
+// s: Huffman Table length
+// c: Input bit length
+// n: Huffman encoding token length (excluding raw encoding)
+// b: Output bit length
+module mkEncoder(HuffmanTable#(s,c,n) ht, Encoder#(c, b) ifc);
+	// Max length of each token
+	Integer maxTokenLen = valueOf(n) + valueOf(c);
+	
+	FIFO#(Bit#(c)) inputFIFO <- mkFIFO;
+	FIFO#(Bit#(b)) outputFIFO <- mkFIFO; 
+	
+	// Encoding stuff
+	FIFO#(Encoding#(TAdd#(n, c))) encodingFIFO <- mkFIFO; 
+	
+	// Chunking stuff
+	Reg#(Bit#(6)) w_index <- mkReg(0);
+	Reg#(Bit#(6)) r_index <- mkReg(0);
+	Vector#(64,Ehr#(2, Maybe#(Bit#(1)))) bitBuffer <- replicateM(mkEhr(tagged Invalid));
+
+	rule stage_encode;
+		let in = inputFIFO.first; inputFIFO.deq;
+		Bool hit = False;
+		Encoding#(TAdd#(n, c)) encode = ?;
+		// All tokens in the Huffman table are REVERSED
+		for (Integer i = 0; i <  valueof(s); i=i+1) begin
+			if ( in == ht[i].tag )begin
+				encode = Encoding{size: ht[i].size, token: {ht[i].token, 0'}};
+				hit = True;
+			end
+		end
+		if(!hit)begin
+			// Not found in encoding table, we just add 111...111 before the input
+			encode = Encoding{size: fromInteger(maxTokenLen), token: {in, 1'}};
+		end
+		$display("%t Encoder: encode %d -> %bb'%d", $time, in, encode.token, encode.size);
+		encodingFIFO.enq(encode);
+	endrule
+
+	rule stage_chunk (!isValid(bitBuffer[w_index + encodingFIFO.first.size - 1][1])); // Make sure there is enough room for write
+		Encoding#(TAdd#(n, c)) encode = encodingFIFO.first; encodingFIFO.deq;
+		for (Integer i = 0; i < maxTokenLen; i=i+1) begin
+			if (fromInteger(i) < encode.size) begin
+				bitBuffer[w_index + fromInteger(i)][1] <= tagged Valid encode.token[i];
+			end
+		end
+		
+		// Automatically warp
+		w_index <= w_index + encode.size;
+		$display("%t Encoder: chunk %b, w_ptr=%d", $time, encode.token, w_index);
+	endrule
+
+	rule stage_read (isValid(bitBuffer[r_index + fromInteger(valueOf(b)) - 1][0])); // Make sure there is enough data to read
+		Bit#(b) out = ?;
+		for (Integer i = 0; i < valueOf(b); i=i+1) begin
+			out[i] = fromMaybe(?, bitBuffer[r_index + fromInteger(i)][0]);
+			bitBuffer[r_index + fromInteger(i)][0] <= tagged Invalid;
+		end
+		
+		// Automatically warp
+		r_index <= r_index + fromInteger(valueOf(b));
+		
+		$display("%t Encoder: output %b",$time, out);
+		outputFIFO.enq(out);
+	endrule
+  
+	interface Put request = toPut(inputFIFO);
+	interface Get response = toGet(outputFIFO);
+
+endmodule

--- a/huffman/Encoder_v2.bsv
+++ b/huffman/Encoder_v2.bsv
@@ -43,13 +43,13 @@ module mkEncoder(HuffmanTable#(s,c,n) ht, Encoder#(c, b) ifc);
 		// All tokens in the Huffman table are REVERSED
 		for (Integer i = 0; i <  valueof(s); i=i+1) begin
 			if ( in == ht[i].tag )begin
-				encode = Encoding{size: ht[i].size, token: {ht[i].token, 0'}};
+				encode = Encoding{size: ht[i].size, token: reverseBits({ht[i].token, '0})};
 				hit = True;
 			end
 		end
 		if(!hit)begin
 			// Not found in encoding table, we just add 111...111 before the input
-			encode = Encoding{size: fromInteger(maxTokenLen), token: {in, 1'}};
+			encode = Encoding{size: fromInteger(maxTokenLen), token: reverseBits({'1, in})};
 		end
 		$display("%t Encoder: encode %d -> %bb'%d", $time, in, encode.token, encode.size);
 		encodingFIFO.enq(encode);

--- a/huffman/HuffmanTable.bsv
+++ b/huffman/HuffmanTable.bsv
@@ -10,26 +10,12 @@ typedef struct {
 typedef Vector#(s, HuffmanTableItem#(m, n)) HuffmanTable#(numeric type s, numeric type m, numeric type n);
 
 HuffmanTable#(8, 12, 6) huffmanTable1 = cons(
-HuffmanTableItem{size:2, tag: 0, token: 6'b01}, cons(
-HuffmanTableItem{size:4, tag: 1, token: 6'b0011}, cons(
-HuffmanTableItem{size:4, tag:-1, token: 6'b1011}, cons(
-HuffmanTableItem{size:5, tag: 2, token: 6'b00111}, cons(
-HuffmanTableItem{size:5, tag:-2, token: 6'b10111}, cons(
-HuffmanTableItem{size:6, tag: 3, token: 6'b001111}, cons(
-HuffmanTableItem{size:6, tag:-3, token: 6'b101111}, cons(
-HuffmanTableItem{size:6, tag:-4, token: 6'b011111},
+HuffmanTableItem{size:2, tag: 0, token: 6'b100000}, cons(
+HuffmanTableItem{size:4, tag: 1, token: 6'b110000}, cons(
+HuffmanTableItem{size:4, tag:-1, token: 6'b110100}, cons(
+HuffmanTableItem{size:5, tag: 2, token: 6'b111000}, cons(
+HuffmanTableItem{size:5, tag:-2, token: 6'b111010}, cons(
+HuffmanTableItem{size:6, tag: 3, token: 6'b111100}, cons(
+HuffmanTableItem{size:6, tag:-3, token: 6'b111101}, cons(
+HuffmanTableItem{size:6, tag:-4, token: 6'b111110},
 nil))))))));
-
-/*
-case (inCoeff)
-			0: encoding[i] = Encoding{size:2,value:6'b000001, coeff: ?};       
-			1: encoding[i] = Encoding{size:4,value:6'b000011, coeff: ?};
-			-1:encoding[i] = Encoding{size:4,value:6'b001011, coeff: ?};
-			2: encoding[i] = Encoding{size:5,value:6'b000111, coeff: ?};
-			-2:encoding[i] = Encoding{size:5,value:6'b010111, coeff: ?};
-			3: encoding[i] = Encoding{size:6,value:6'b001111, coeff: ?};
-			-3:encoding[i] = Encoding{size:6,value:6'b101111, coeff: ?};
-			-4:encoding[i] = Encoding{size:6,value:6'b011111, coeff: ?};
-			default:encoding[i] = Encoding{size:22,value:6'b111111, coeff:inCoeffB};
-			endcase
-			*/

--- a/huffman/HuffmanTable.bsv
+++ b/huffman/HuffmanTable.bsv
@@ -1,0 +1,35 @@
+import Vector::*;
+
+typedef struct {
+	Bit#(6) size;
+	Bit#(m) tag;
+	Bit#(n) token;
+} HuffmanTableItem#(numeric type m, numeric type n) deriving (Bits,Eq);
+
+// s: table length, m: tag length, n: max token length
+typedef Vector#(s, HuffmanTableItem#(m, n)) HuffmanTable#(numeric type s, numeric type m, numeric type n);
+
+HuffmanTable#(8, 12, 6) huffmanTable1 = cons(
+HuffmanTableItem{size:2, tag: 0, token: 6'b01}, cons(
+HuffmanTableItem{size:4, tag: 1, token: 6'b0011}, cons(
+HuffmanTableItem{size:4, tag:-1, token: 6'b1011}, cons(
+HuffmanTableItem{size:5, tag: 2, token: 6'b00111}, cons(
+HuffmanTableItem{size:5, tag:-2, token: 6'b10111}, cons(
+HuffmanTableItem{size:6, tag: 3, token: 6'b001111}, cons(
+HuffmanTableItem{size:6, tag:-3, token: 6'b101111}, cons(
+HuffmanTableItem{size:6, tag:-4, token: 6'b011111},
+nil))))))));
+
+/*
+case (inCoeff)
+			0: encoding[i] = Encoding{size:2,value:6'b000001, coeff: ?};       
+			1: encoding[i] = Encoding{size:4,value:6'b000011, coeff: ?};
+			-1:encoding[i] = Encoding{size:4,value:6'b001011, coeff: ?};
+			2: encoding[i] = Encoding{size:5,value:6'b000111, coeff: ?};
+			-2:encoding[i] = Encoding{size:5,value:6'b010111, coeff: ?};
+			3: encoding[i] = Encoding{size:6,value:6'b001111, coeff: ?};
+			-3:encoding[i] = Encoding{size:6,value:6'b101111, coeff: ?};
+			-4:encoding[i] = Encoding{size:6,value:6'b011111, coeff: ?};
+			default:encoding[i] = Encoding{size:22,value:6'b111111, coeff:inCoeffB};
+			endcase
+			*/

--- a/huffman/huffmanLoopBack.bsv
+++ b/huffman/huffmanLoopBack.bsv
@@ -32,7 +32,7 @@ module mkHuffmanLoopBack (HuffmanLoopBack#(p) ifc);
    rule e_to_b2bb;
       let x <- e.response.get();
       bb2b.request.put(x);
-      $display("encode to bytes:",fshow(x));
+      //display("encode to bytes:",fshow(x));
    endrule
 
    rule bb2b_to_d;
@@ -43,7 +43,7 @@ module mkHuffmanLoopBack (HuffmanLoopBack#(p) ifc);
    rule d_to_vect;
       let x <- d.response.get();
       Vector#(p,Coeff) outVect = replicate(0);
-      $display("count:",count);
+      //$display("count:",count);
       //$display("coeff:",x);
       if (count == fromInteger(valueOf(TSub#(p,1)))) begin
 	 for (Integer i = 0; i < valueOf(TSub#(p,1)); i=i+1) begin
@@ -59,11 +59,7 @@ module mkHuffmanLoopBack (HuffmanLoopBack#(p) ifc);
       end
    endrule
 
-   interface Put request;
-      method Action put (Vector#(p,Coeff) x );
-	 inFIFO.enq(x);
-      endmethod
-   endinterface
+   interface Put request = toPut(inFIFO);
    interface Get response = toGet(outFIFO);
 
 endmodule

--- a/scemi_dwt_encode_decode_idwt/SceMiLayer.bsv
+++ b/scemi_dwt_encode_decode_idwt/SceMiLayer.bsv
@@ -16,6 +16,7 @@ import DWT2DML::*;
 
 import Encoder::*;
 import Decoder::*;
+import HuffmanLoopBack::8;
 
 typedef 1024 N;
 typedef 1024 M;


### PR DESCRIPTION
Hi Ariana,

I cleaned up the `Encoder` and `Decoder` codes a bit and now they are `Encoder_v2` and `Decoder_v2`.  The bit buffer is now using EHRs so there is no more conflicting methods. I tested the throughput working at 1 Sample/cycle. 

I guess we can at least do a full synthesis before the weekend.

Yuan
